### PR TITLE
Upgrade to jfrog-cli-v2-jf

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,22 @@
 Plugin:
 
 ```shell
-asdf plugin add jfrog-cli-v2-jf
+asdf plugin add jfrog-cli
 # or
 asdf plugin add jfrog-cli https://github.com/LozanoMatheus/asdf-jfrog-cli.git
-asdf plugin add jfrog-cli-v2-jf https://github.com/jmcubel/asdf-jfrog-cli.git
 ```
 
 jfrog-cli:
 
 ```shell
 # Show all installable versions
-asdf list-all jfrog-cli-v2-jf
+asdf list-all jfrog-cli
 
 # Install specific version
-asdf install jfrog-cli-v2-jf latest
+asdf install jfrog-cli latest
 
 # Set a version globally (on your ~/.tool-versions file)
-asdf global jfrog-cli-v2-jf latest
+asdf global jfrog-cli latest
 
 # Now jfrog-cli commands are available
 Please, check the official documentation in the section Commands Summary:

--- a/README.md
+++ b/README.md
@@ -22,22 +22,23 @@
 Plugin:
 
 ```shell
-asdf plugin add jfrog-cli
+asdf plugin add jfrog-cli-v2-jf
 # or
 asdf plugin add jfrog-cli https://github.com/LozanoMatheus/asdf-jfrog-cli.git
+asdf plugin add jfrog-cli-v2-jf https://github.com/jmcubel/asdf-jfrog-cli.git
 ```
 
 jfrog-cli:
 
 ```shell
 # Show all installable versions
-asdf list-all jfrog-cli
+asdf list-all jfrog-cli-v2-jf
 
 # Install specific version
-asdf install jfrog-cli latest
+asdf install jfrog-cli-v2-jf latest
 
 # Set a version globally (on your ~/.tool-versions file)
-asdf global jfrog-cli latest
+asdf global jfrog-cli-v2-jf latest
 
 # Now jfrog-cli commands are available
 Please, check the official documentation in the section Commands Summary:

--- a/bin/download
+++ b/bin/download
@@ -15,8 +15,11 @@ os_name="$(get_os_name)"
 arch="$(get_arch)"
 
 release_file="${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}"
-
-download_release "${ASDF_INSTALL_VERSION}" "${os_name}" "${arch}" "${release_file}"
+if [ "$os_name" == "mac" ] && [ "$arch" != "arm64" ] ; then
+    download_release "${ASDF_INSTALL_VERSION}" "${os_name}" "386" "${release_file}"
+else 
+    download_release "${ASDF_INSTALL_VERSION}" "${os_name}" "${arch}" "${release_file}"
+fi
 
 \mv "${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}" "${ASDF_DOWNLOAD_PATH}/${TOOL_SHORT_NAME}"
 

--- a/bin/download
+++ b/bin/download
@@ -15,10 +15,10 @@ os_name="$(get_os_name)"
 arch="$(get_arch)"
 
 release_file="${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}"
-if [ "$os_name" == "mac" ] && [ "$arch" != "arm64" ] ; then
-    download_release "${ASDF_INSTALL_VERSION}" "${os_name}" "386" "${release_file}"
-else 
-    download_release "${ASDF_INSTALL_VERSION}" "${os_name}" "${arch}" "${release_file}"
+if [ "$os_name" == "mac" ] && [ "$arch" != "arm64" ]; then
+  download_release "${ASDF_INSTALL_VERSION}" "${os_name}" "386" "${release_file}"
+else
+  download_release "${ASDF_INSTALL_VERSION}" "${os_name}" "${arch}" "${release_file}"
 fi
 
 \mv "${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}" "${ASDF_DOWNLOAD_PATH}/${TOOL_SHORT_NAME}"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 REPO="jfrog/jfrog-cli"
-TOOL_NAME="jfrog-cli-v2-jf"
+TOOL_NAME="jfrog-cli"
 TOOL_SHORT_NAME="jf"
 TOOL_TEST="${TOOL_SHORT_NAME} --version"
 
@@ -53,14 +53,13 @@ download_release() {
 
   if [ "$cli_major_version" -eq 2 ]; then
     effective_cli_major_version=2-jf
-    jfrog_client=jf
+    jfrog_cli_name=jf
   else
     effective_cli_major_version=$cli_major_version
-    jfrog_client=jfrog
+    jfrog_cli_name=jfrog
   fi 
 
-  #url="https://releases.jfrog.io/artifactory/jfrog-cli/v${cli_major_version}/${version}/jfrog-cli-${os_name}-${arch}/jfrog"
-  url="https://releases.jfrog.io/artifactory/jfrog-cli/v${effective_cli_major_version}/${version}/jfrog-cli-${os_name}-${arch}/${jfrog_client}"
+  url="https://releases.jfrog.io/artifactory/jfrog-cli/v${effective_cli_major_version}/${version}/jfrog-cli-${os_name}-${arch}/${jfrog_cli_name}"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${CURL_OPTS[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -57,7 +57,7 @@ download_release() {
   else
     effective_cli_major_version=$cli_major_version
     jfrog_cli_name=jfrog
-  fi 
+  fi
 
   url="https://releases.jfrog.io/artifactory/jfrog-cli/v${effective_cli_major_version}/${version}/jfrog-cli-${os_name}-${arch}/${jfrog_cli_name}"
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -3,8 +3,7 @@
 set -euo pipefail
 
 REPO="jfrog/jfrog-cli"
-TOOL_LONG_NAME="jfrog-cli"
-TOOL_NAME="jfrog"
+TOOL_NAME="jfrog-cli-v2-jf"
 TOOL_SHORT_NAME="jf"
 TOOL_TEST="${TOOL_SHORT_NAME} --version"
 
@@ -31,7 +30,7 @@ list_github_tags() {
   local RC="0"
   set +euo pipefail
   while [ ${RC} -eq 0 ]; do
-    GH_RELEASES_PAGE=$((${GH_RELEASES_PAGE} + 1))
+    GH_RELEASES_PAGE=$((GH_RELEASES_PAGE + 1))
     GH_RELEASES="${GH_RELEASES}$(curl "${CURL_OPTS[@]}" "https://api.github.com/repos/${REPO}/releases?per_page=100&page=${GH_RELEASES_PAGE}" | awk '/tag_name/{ rc = 1; gsub(/,|"/,"") ; print $2 }; END { exit !rc }')"
     RC="${?}"
   done
@@ -52,7 +51,16 @@ download_release() {
   arch="$3"
   filename="$4"
 
-  url="https://releases.jfrog.io/artifactory/jfrog-cli/v${cli_major_version}/${version}/jfrog-cli-${os_name}-${arch}/jfrog"
+  if [ "$cli_major_version" -eq 2 ]; then
+    effective_cli_major_version=2-jf
+    jfrog_client=jf
+  else
+    effective_cli_major_version=$cli_major_version
+    jfrog_client=jfrog
+  fi 
+
+  #url="https://releases.jfrog.io/artifactory/jfrog-cli/v${cli_major_version}/${version}/jfrog-cli-${os_name}-${arch}/jfrog"
+  url="https://releases.jfrog.io/artifactory/jfrog-cli/v${effective_cli_major_version}/${version}/jfrog-cli-${os_name}-${arch}/${jfrog_client}"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${CURL_OPTS[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"


### PR DESCRIPTION
Hi @LozanoMatheus .

Since jfrog-cli-v1 (jfrog) clients are deprecated and it is recommended to use jfrog-cli-v2 (jf) clients (see https://jfrog.com/help/r/jfrog-cli/jfrog-cli-v2) I've made a few changes to install v2 binaries instead the former ones.

Would you mind taking a look at this PR and merging it to your repository if appropriate?

Regards.

JM

