### PR TITLE
fix: Support arm64 architecture

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -118,7 +118,7 @@ get_arch() {
   arm | armv7l)
     arch="arm"
     ;;
-  aarch64)
+  aarch64 | arm64)
     arch="arm64"
     ;;
   s390x)


### PR DESCRIPTION
It adds support for installations on Apple Silicon devices (arm64 chipsets).